### PR TITLE
Implementing auto-delegation to Vonage::Client

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# 1.2.0
+
+* Minor implementation improvements. See PR [#5](https://github.com/Vonage/vonage-rails/pull/5) for details.
+
 # 1.1.0
 
 * Migrating to Vonage [https://github.com/Vonage/vonage-rails](https://github.com/Vonage/vonage-rails) from [https://github.com/Nexmo/nexmo-rails](https://github.com/Nexmo/nexmo-rails)

--- a/lib/vonage_rails.rb
+++ b/lib/vonage_rails.rb
@@ -1,5 +1,6 @@
 require 'vonage'
 require 'forwardable'
+require 'ostruct'
 
 module Vonage
   class << self
@@ -7,11 +8,7 @@ module Vonage
 
     attr_accessor :client
 
-    def_delegators :@client, :account, :alerts, :applications, 
-                   :conversations, :conversions, :files, :messages, 
-                   :messaging, :numbers, :number_insight, :number_insight_2,
-                   :pricing, :redact, :secrets, :sms, :signature, :subaccounts,
-                   :tfa, :users, :verify, :verify2, :video, :voice
+    def_delegators :@client, *::Vonage::Client.instance_methods(false) - [:config]
                    
     def setup(&block)
       config = OpenStruct.new 

--- a/lib/vonage_rails/version.rb
+++ b/lib/vonage_rails/version.rb
@@ -1,5 +1,5 @@
 # :nocov:
 module VonageRails
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end
 # :nocov:

--- a/vonage_rails.gemspec
+++ b/vonage_rails.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency('jwt', '~> 2')
-  spec.add_dependency('vonage', '~> 7.19.0')
+  spec.add_dependency('vonage', '~> 7.19')
   spec.add_dependency('dotenv-rails')
   spec.add_development_dependency('rspec')
   spec.add_development_dependency('rails')


### PR DESCRIPTION
This PR:

- Updates the implementation of `@def_delegators` in the `Vonage` module to automatically delegate to methods in the `Client` class of the [Vonage Ruby SDK](https://github.com/Vonage/vonage-ruby-sdk). 
- Amends the dependency on the `vonage` gem so that this library uses the latest major version

Motivation: these changes have been made to remove the need to update this library when new minor versions of the [Vonage Ruby SDK](https://github.com/Vonage/vonage-ruby-sdk) are released and/or new methods are added to the `Client` class of the [Vonage Ruby SDK](https://github.com/Vonage/vonage-ruby-sdk) (e.g. when implementing a new API product). 